### PR TITLE
CPU数によって並列度を変える

### DIFF
--- a/evaluation.go
+++ b/evaluation.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 )
 
@@ -36,11 +37,15 @@ func DependencyAccuracy(model *Model, sents []*Sentence) float64 {
 	predHeads := make([][]int, 0)
 	w := model.AveragedWeight()
 
+	cpus := runtime.NumCPU()
+	semaphore := make(chan int, cpus)
 	for _, sent := range sents {
 		wg.Add(1)
 		go func(sent *Sentence) {
 			defer wg.Done()
+			semaphore <- 1
 			Decode(&w, sent)
+			<-semaphore
 		}(sent)
 	}
 	wg.Wait()

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"runtime"
 )
 
 func shuffle(data []*Sentence) {
@@ -16,6 +17,7 @@ func shuffle(data []*Sentence) {
 }
 
 func main() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
 	data, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- 関連: https://github.com/syou6162/go-easy-first/pull/14

CPU数ガン無視で並列にやっているので、大きめの学習データでやるとメモリ消費量がどんどん増えていっている。手元でやる分には4並列くらいでちょうどよい。