### PR TITLE
jenkins hashを使う

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -4,7 +4,7 @@ func isFinished(state *State) bool {
 	return len(state.pending) == 1
 }
 
-func decode(weight *map[string]float64, state *State) {
+func decode(weight *map[int]float64, state *State) {
 	if isFinished(state) {
 		// Do nothing
 	} else {
@@ -15,7 +15,7 @@ func decode(weight *map[string]float64, state *State) {
 	}
 }
 
-func Decode(weight *map[string]float64, sent *Sentence) {
+func Decode(weight *map[int]float64, sent *Sentence) {
 	tmp := make([]*Word, len(sent.words))
 	copy(tmp, sent.words)
 	s := NewState(sent.words)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -15,7 +15,7 @@ func TestDecode(t *testing.T) {
 		makeWord(".", ".", 5, 3),
 	)
 	sent := Sentence{words: words}
-	weight := make(map[string]float64)
+	weight := make(map[int]float64)
 
 	s := NewState(sent.words)
 	decode(&weight, s)

--- a/feature.go
+++ b/feature.go
@@ -152,7 +152,39 @@ func extractFeatures(state *State, actName string, idx int) []string {
 	return features
 }
 
-func ExtractFeatures(state *State, pair ActionIndexPair) ([]string, error) {
+func mod(n, m int) int {
+	if n < 0 {
+		return (m - (-n % m)) % m
+	} else {
+		return n % m
+	}
+}
+
+var MaxFeatureLength = 1000000
+
+func JenkinsHash(s string) int {
+	hash := 0
+	for _, b := range []byte(s) {
+		hash += int(b)
+		hash += hash << 10
+		hash ^= hash >> 6
+	}
+
+	hash += hash << 3
+	hash ^= hash >> 11
+	hash += hash << 15
+
+	return mod(hash, MaxFeatureLength)
+}
+
+func ExtractFeatures(state *State, pair ActionIndexPair) ([]int, error) {
 	actName := runtime.FuncForPC(reflect.ValueOf(pair.action).Pointer()).Name()
-	return extractFeatures(state, actName, pair.index), nil
+
+	featStrs := extractFeatures(state, actName, pair.index)
+	features := make([]int, len(featStrs))
+	for idx, s := range featStrs {
+		features[idx] = JenkinsHash(s)
+	}
+
+	return features, nil
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	goldSents := sentences[0:splitPos]
 	devSents := sentences[splitPos+1 : len(sentences)-1]
 
-	model := Model{make(map[string]float64), make(map[string]float64), 1}
+	model := Model{make(map[int]float64), make(map[int]float64), 1}
 
 	for iter := 0; iter < 10; iter++ {
 		shuffle(goldSents)

--- a/perceptron.go
+++ b/perceptron.go
@@ -92,7 +92,7 @@ func CandidateActions(state *State) []ActionIndexPair {
 	return result
 }
 
-func DotProduct(weight *map[string]float64, fv []string) float64 {
+func DotProduct(weight *map[int]float64, fv []int) float64 {
 	sum := 0.0
 	for _, f := range fv {
 		if v, ok := (*weight)[f]; ok {
@@ -102,7 +102,7 @@ func DotProduct(weight *map[string]float64, fv []string) float64 {
 	return sum
 }
 
-func BestActionIndexPair(weight *map[string]float64, state *State) ActionIndexPair {
+func BestActionIndexPair(weight *map[int]float64, state *State) ActionIndexPair {
 	bestScore := math.Inf(-1)
 	pairs := CandidateActions(state)
 	bestPair := pairs[0]
@@ -117,7 +117,7 @@ func BestActionIndexPair(weight *map[string]float64, state *State) ActionIndexPa
 	return bestPair
 }
 
-func BestAllowedActionIndexPair(weight *map[string]float64, state *State, pairs []ActionIndexPair) ActionIndexPair {
+func BestAllowedActionIndexPair(weight *map[int]float64, state *State, pairs []ActionIndexPair) ActionIndexPair {
 	bestScore := math.Inf(-1)
 	bestPair := pairs[0]
 	for _, pair := range pairs {
@@ -132,12 +132,12 @@ func BestAllowedActionIndexPair(weight *map[string]float64, state *State, pairs 
 }
 
 type Model struct {
-	weight    map[string]float64
-	cumWeight map[string]float64
+	weight    map[int]float64
+	cumWeight map[int]float64
 	count     int
 }
 
-func (model *Model) updateWeight(goldFeatureVector *[]string, predictFeatureVector *[]string) {
+func (model *Model) updateWeight(goldFeatureVector *[]int, predictFeatureVector *[]int) {
 	for _, feat := range *goldFeatureVector {
 		w, _ := model.weight[feat]
 		cumW, _ := model.cumWeight[feat]
@@ -186,8 +186,8 @@ func (model *Model) Update(gold *Sentence) {
 }
 
 // w_t - w_cum / t
-func (model *Model) AveragedWeight() map[string]float64 {
-	avg := make(map[string]float64)
+func (model *Model) AveragedWeight() map[int]float64 {
+	avg := make(map[int]float64)
 	for k, v := range model.weight {
 		avg[k] = v
 	}

--- a/perceptron_test.go
+++ b/perceptron_test.go
@@ -101,36 +101,36 @@ func TestCandidateActions(t *testing.T) {
 }
 
 func TestUpdateWeight(t *testing.T) {
-	model := Model{make(map[string]float64), make(map[string]float64), 1}
-	gold := []string{"1", "2", "3"}
-	predict := []string{"1", "3", "4"}
+	model := Model{make(map[int]float64), make(map[int]float64), 1}
+	gold := []int{1, 2, 3}
+	predict := []int{1, 3, 4}
 	model.updateWeight(&gold, &predict)
 
-	if w, _ := model.weight["1"]; w != 0 {
+	if w, _ := model.weight[1]; w != 0 {
 		t.Error("weight of '1' must be 0")
 	}
-	if w, _ := model.weight["2"]; w != 1 {
+	if w, _ := model.weight[2]; w != 1 {
 		t.Error("weight of '2' must be 1")
 	}
-	if w, _ := model.weight["3"]; w != 0 {
+	if w, _ := model.weight[3]; w != 0 {
 		t.Error("weight of '3' must be 0")
 	}
-	if w, _ := model.weight["4"]; w != -1 {
+	if w, _ := model.weight[4]; w != -1 {
 		t.Error("weight of '4' must be -1")
 	}
 
 	model.updateWeight(&gold, &predict)
 
-	if w, _ := model.cumWeight["1"]; w != 0 {
+	if w, _ := model.cumWeight[1]; w != 0 {
 		t.Error("cumWeight of '1' must be 0")
 	}
-	if w, _ := model.cumWeight["2"]; w != 3 {
+	if w, _ := model.cumWeight[2]; w != 3 {
 		t.Error("cumWeight of '2' must be 3")
 	}
-	if w, _ := model.cumWeight["3"]; w != 0 {
+	if w, _ := model.cumWeight[3]; w != 0 {
 		t.Error("cumWeight of '3' must be 0")
 	}
-	if w, _ := model.cumWeight["4"]; w != -3 {
+	if w, _ := model.cumWeight[4]; w != -3 {
 		t.Error("cumWeight of '4' must be -3")
 	}
 }
@@ -146,7 +146,7 @@ func TestUpdate(t *testing.T) {
 		makeWord(".", ".", 5, 3),
 	)
 	sent := Sentence{words: words}
-	model := Model{make(map[string]float64), make(map[string]float64), 1}
+	model := Model{make(map[int]float64), make(map[int]float64), 1}
 	model.Update(&sent)
 	if model.count == 1 {
 		t.Error("count must be greater than 1")

--- a/state.go
+++ b/state.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-type FvCache map[string][]string
+type FvCache map[string][]int
 
 type State struct {
 	pending []*Word
@@ -56,7 +56,7 @@ func (state *State) ResetFvCache(index int) {
 	}
 }
 
-func (state *State) GetFvCache(pair ActionIndexPair) []string {
+func (state *State) GetFvCache(pair ActionIndexPair) []int {
 	key := state.cacheKeyStr(pair)
 	if fv, ok := state.fvCache[key]; ok {
 		return fv


### PR DESCRIPTION
pprofで見ているとDotProdの計算時間が結構バカにならない感じになっていた。今は文字列がkeyのhashを何回も引いているので、そこをid化すればよさそう。単純にidに置き換えていってもいいけど、次元が決まっていたほうが後続の処理はやりやすいので、jenkins hashでやる。