### PR TITLE
[Bug]学習/デコードの前にword.childrenを初期化しなおす

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -16,8 +16,6 @@ func decode(weight *[]float64, state *State) {
 }
 
 func Decode(weight *[]float64, sent *Sentence) {
-	tmp := make([]*Word, len(sent.words))
-	copy(tmp, sent.words)
 	s := NewState(sent.words)
 	decode(weight, s)
 

--- a/state.go
+++ b/state.go
@@ -33,6 +33,9 @@ func (state *State) InitFvCache() {
 }
 
 func NewState(pending []*Word) *State {
+	for _, w := range pending {
+		w.children = make([]*Word, 0)
+	}
 	p := make([]*Word, len(pending))
 	copy(p, pending)
 	state := State{p, make(map[int]int), FvCache{}}


### PR DESCRIPTION
初回以降word.childrenに前回以前にデコードした結果が残っている。left-most child等の素性に影響があるので、Stateを作るときに初期化しておいたほうが安全か。