### PR TITLE
word.childrenには[]*Wordではなく[]Wordを持つようにする

### DIFF
--- a/state.go
+++ b/state.go
@@ -34,7 +34,7 @@ func (state *State) InitFvCache() {
 
 func NewState(pending []*Word) *State {
 	for _, w := range pending {
-		w.children = make([]*Word, 0)
+		w.children = make([]Word, 0)
 	}
 	p := make([]*Word, len(pending))
 	copy(p, pending)

--- a/word.go
+++ b/word.go
@@ -8,24 +8,24 @@ type Word struct {
 	idx      int
 	head     int
 	predHead int
-	children []*Word
+	children []Word
 }
 
 func makeWord(surface string, posTag string, idx int, head int) *Word {
-	return &Word{surface, surface, posTag, posTag, idx, head, head, make([]*Word, 0)}
+	return &Word{surface, surface, posTag, posTag, idx, head, head, make([]Word, 0)}
 }
 
 func makeRootWord() *Word {
 	return makeWord("*ROOT*", "*ROOT*", 0, -1)
 }
 
-func (word *Word) appendChild(c *Word) []*Word {
-	word.children = append(word.children, c)
+func (word *Word) appendChild(c *Word) []Word {
+	word.children = append(word.children, *c)
 	return word.children
 }
 
-func (word *Word) prependChild(c *Word) []*Word {
-	word.children = append([]*Word{c}, word.children...)
+func (word *Word) prependChild(c *Word) []Word {
+	word.children = append([]Word{*c}, word.children...)
 	return word.children
 }
 
@@ -33,7 +33,7 @@ func (word *Word) LeftMostChild() *Word {
 	if len(word.children) == 0 {
 		return nil
 	} else {
-		return word.children[0]
+		return &word.children[0]
 	}
 }
 
@@ -41,6 +41,6 @@ func (word *Word) RightMostChild() *Word {
 	if len(word.children) == 0 {
 		return nil
 	} else {
-		return word.children[len(word.children)-1]
+		return &word.children[len(word.children)-1]
 	}
 }


### PR DESCRIPTION
[]*Wordではなく[]Wordでword.childrenを持つようにする。ビームサーチ等で思わぬ変更とかがあって怖い。

パフォマンス観点で問題になるかと思ったが、ほぼ無視できる時間であった。